### PR TITLE
优化登陆界面内存，解决容易导致卡顿的问题

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,6 +13,12 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="myModules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,8 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/EBear.iml" filepath="$PROJECT_DIR$/EBear.iml" />
+      <module fileurl="file://$PROJECT_DIR$/EBear.iml" filepath="$PROJECT_DIR$/EBear.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/app/src/main/java/com/example/tangyangkai/ebear/adapter/NoteAdapter.java
+++ b/app/src/main/java/com/example/tangyangkai/ebear/adapter/NoteAdapter.java
@@ -13,7 +13,6 @@ import com.example.tangyangkai.ebear.model.Note;
 import com.example.tangyangkai.ebear.model.Person;
 import com.example.tangyangkai.ebear.view.NoScrollGridView;
 import com.example.tangyangkai.ebear.view.RoundImageView;
-import com.lidroid.xutils.BitmapUtils;
 import com.nostra13.universalimageloader.core.ImageLoader;
 
 import java.util.ArrayList;

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/login_bg"
     tools:context="com.example.tangyangkai.ebear.activity.LoginActivity">
 
     <RelativeLayout


### PR DESCRIPTION
1、删除多余代码  
2、LoginActivity非常卡，原因是背景图片占用过多内存。建议直接删除或者使用图片采样率优化图片。